### PR TITLE
fix: replace ansible 2.9 with ansible 4 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM ubuntu:latest
 ARG SEMAPHORE_VERSION=2.6.9
 
 RUN apt update && apt install -y curl && curl -O -L https://github.com/ansible-semaphore/semaphore/releases/download/v${SEMAPHORE_VERSION}/semaphore_${SEMAPHORE_VERSION}_linux_arm64.deb
-RUN apt install -y ansible ./semaphore_${SEMAPHORE_VERSION}_linux_arm64.deb
+RUN apt install -y python3-pip && pip install ansible
+RUN apt install -y ./semaphore_${SEMAPHORE_VERSION}_linux_arm64.deb
 CMD ["/usr/bin/semaphore"]


### PR DESCRIPTION
* apt provides a stable but outdated version of ansible
* installing ansible via pip installs the latest release